### PR TITLE
Modified macros in python_bindings.c for Py2 and Py3 builds.

### DIFF
--- a/matrix.c
+++ b/matrix.c
@@ -178,7 +178,7 @@ int equal_matrix(Matrix a, Matrix b, double tolerance) {
   assert(a.cols == b.cols);
   for (i = 0; i < a.rows; ++i) {
     for (j = 0; j < a.cols; ++j) {
-      if (abs(a.data[i][j] - b.data[i][j]) > tolerance) {
+      if (fabs(a.data[i][j] - b.data[i][j]) > tolerance) {
 	return 0;
       }
     }


### PR DESCRIPTION
Also updated matrix.c to use fabs() instead of abs() for floating point ops to get
rid of the warning on compile.

This should build on 2.6+ too